### PR TITLE
Update doT.php

### DIFF
--- a/doT.php
+++ b/doT.php
@@ -11,6 +11,7 @@ class doT {
     public $functionBody;
     private $functionCode;
     public $def;
+    public $argName = '$it';
 
     public function resolveDefs ($block) {
         $me = $this;
@@ -91,7 +92,9 @@ class doT {
 
         $this->functionBody = $func;
 
-        return @create_function ('$it', $func);
+        return eval('return function (' . $this->argName . ') use ($func) {
+            return eval($func);
+        };');
     }
 
     public function execute ($data) {


### PR DESCRIPTION
Fixed for PHP8 (used eval + lambda for creating the return function instead of the removed "create_function" - needed eval for the argName feature)
Added the option to set the argName as in the original doT.js by setting the public property "argName" to something like '$myvar'